### PR TITLE
Fix pagination condition in DespesasRepository

### DIFF
--- a/backend-java/src/main/java/br/com/organomeno/despesas/repository/DespesasRepository.java
+++ b/backend-java/src/main/java/br/com/organomeno/despesas/repository/DespesasRepository.java
@@ -38,7 +38,7 @@ public class DespesasRepository implements PanacheRepositoryBase<Despesas,Intege
 
         PanacheQuery<Despesas> despesas = find(query.toString(),parametros);
 
-        if (despesasFiltroDTO.getPageNum() != null || despesasFiltroDTO.getPageSize() != null) {
+        if (despesasFiltroDTO.getPageNum() != null && despesasFiltroDTO.getPageSize() != null) {
             despesas.page(Page.of(despesasFiltroDTO.getPageNum(), despesasFiltroDTO.getPageSize()));
             return despesas.stream().toList();
         }


### PR DESCRIPTION
## Summary
- require both page number and page size before applying pagination in DespesasRepository to avoid null values reaching Page.of

## Testing
- mvn -q test *(fails: missing Quarkus dependencies because the build cannot reach Maven Central from this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d561aed4fc8325b30d7562ce82af2e